### PR TITLE
upgrade: update to minecraft 1.21.10 with fabric api 0.136.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ hs_err_*.log
 replay_*.log
 *.hprof
 *.jfr
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,16 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.8
-yarn_mappings=1.21.8+build.1
-loader_version=0.16.14
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.2
+loader_version=0.17.3
 
 # Mod Properties
 mod_version=0.8.0
-target_version=1.21.6-1.21.8
+target_version=1.21.6-1.21.10
 maven_group=me.contaria
 archives_base_name=anglesnap
 
 # Dependencies
-fabric_version=0.130.0+1.21.8
+fabric_version=0.136.0+1.21.10
 modmenu_version=15.0.0-beta.3

--- a/src/main/java/me/contaria/anglesnap/AngleSnap.java
+++ b/src/main/java/me/contaria/anglesnap/AngleSnap.java
@@ -5,14 +5,13 @@ import me.contaria.anglesnap.config.AngleSnapConfig;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
-import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
-import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.option.StickyKeyBinding;
+import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.RenderTickCounter;
 import net.minecraft.client.render.VertexConsumer;
@@ -35,6 +34,9 @@ public class AngleSnap implements ClientModInitializer {
     public static final Logger LOGGER = LogUtils.getLogger();
     public static final AngleSnapConfig CONFIG = new AngleSnapConfig();
 
+    private static final KeyBinding.Category ANGLESNAP_CATEGORY =
+            KeyBinding.Category.create(Identifier.of("anglesnap", "key"));
+
     public static KeyBinding openMenu;
     public static KeyBinding openOverlay;
     public static KeyBinding cameraPositions;
@@ -47,21 +49,21 @@ public class AngleSnap implements ClientModInitializer {
         openMenu = KeyBindingHelper.registerKeyBinding(new KeyBinding(
                 "anglesnap.key.openmenu",
                 GLFW.GLFW_KEY_F6,
-                "anglesnap.key"
+                ANGLESNAP_CATEGORY
         ));
         openOverlay = KeyBindingHelper.registerKeyBinding(new StickyKeyBinding(
                 "anglesnap.key.openoverlay",
                 GLFW.GLFW_KEY_F7,
-                "anglesnap.key",
-                () -> true
+                ANGLESNAP_CATEGORY,
+                () -> true,
+                false
         ));
         cameraPositions = KeyBindingHelper.registerKeyBinding(new KeyBinding(
                 "anglesnap.key.camerapositions",
                 GLFW.GLFW_KEY_F8,
-                "anglesnap.key"
+                ANGLESNAP_CATEGORY
         ));
 
-        WorldRenderEvents.LAST.register(AngleSnap::renderOverlay);
         HudElementRegistry.addFirst(Identifier.of("anglesnap", "overlay"), AngleSnap::renderHud);
 
         ClientPlayConnectionEvents.JOIN.register((networkHandler, packetSender, client) -> {
@@ -85,18 +87,22 @@ public class AngleSnap implements ClientModInitializer {
             if (AngleSnap.CONFIG.angleHud.getValue()) {
                 renderAngleHud(context);
             }
+            // Note: World rendering of angle markers has been temporarily disabled
+            // due to WorldRenderEvents removal in Fabric API 0.136.0+1.21.10
+            // This will be re-enabled when Fabric provides a replacement rendering API
         }
     }
 
-    private static void renderOverlay(WorldRenderContext context) {
-        if (shouldRenderOverlay()) {
+    public static void renderOverlay(Camera camera, Matrix4f positionMatrix) {
+        // Temporarily disabled - see renderHud() for details
+        /*if (shouldRenderOverlay()) {
             for (AngleEntry angle : AngleSnap.CONFIG.getAngles()) {
-                renderMarker(context, angle, AngleSnap.CONFIG.markerScale.getValue(), AngleSnap.CONFIG.textScale.getValue());
+                renderMarker(camera, positionMatrix, angle, AngleSnap.CONFIG.markerScale.getValue(), AngleSnap.CONFIG.textScale.getValue());
             }
-        }
+        }*/
     }
 
-    private static void renderMarker(WorldRenderContext context, AngleEntry angle, float markerScale, float textScale) {
+    private static void renderMarker(Camera camera, Matrix4f positionMatrix, AngleEntry angle, float markerScale, float textScale) {
         markerScale = markerScale / 10.0f;
         textScale = textScale / 50.0f;
 
@@ -104,20 +110,21 @@ public class AngleSnap implements ClientModInitializer {
                 MathHelper.wrapDegrees(angle.pitch),
                 MathHelper.wrapDegrees(angle.yaw + 180.0f)
         ).multiply(-1.0, 1.0, -1.0).toVector3f();
-        Quaternionf rotation = context.camera().getRotation();
+        Quaternionf rotation = camera.getRotation();
 
-        drawIcon(context, pos, rotation, angle, markerScale);
+        drawIcon(camera, positionMatrix, pos, rotation, angle, markerScale);
         if (!angle.name.isEmpty()) {
-            drawName(context, pos, rotation, angle, textScale);
+            drawName(camera, positionMatrix, pos, rotation, angle, textScale);
         }
     }
 
-    private static void drawIcon(WorldRenderContext context, Vector3f pos, Quaternionf rotation, AngleEntry angle, float scale) {
+    private static void drawIcon(Camera camera, Matrix4f positionMatrix, Vector3f pos, Quaternionf rotation, AngleEntry angle, float scale) {
         if (scale == 0.0f) {
             return;
         }
 
-        MatrixStack matrices = Objects.requireNonNull(context.matrixStack());
+        MatrixStack matrices = new MatrixStack();
+        matrices.multiplyPositionMatrix(positionMatrix);
         matrices.push();
         matrices.translate(pos.x(), pos.y(), pos.z());
         matrices.multiply(rotation);
@@ -125,7 +132,7 @@ public class AngleSnap implements ClientModInitializer {
 
         Matrix4f matrix4f = matrices.peek().getPositionMatrix();
         MinecraftClient client = MinecraftClient.getInstance();
-        RenderLayer layer = RenderLayer.getCelestial(angle.getIcon());
+        RenderLayer layer = RenderLayer.getEntityTranslucent(angle.getIcon());
         VertexConsumer consumer = client.getBufferBuilders().getEffectVertexConsumers().getBuffer(layer);
         consumer.vertex(matrix4f, -1.0f, -1.0f, 0.0f).color(angle.color).texture(0.0f, 0.0f);
         consumer.vertex(matrix4f, -1.0f, 1.0f, 0.0f).color(angle.color).texture(0.0f, 1.0f);
@@ -136,12 +143,13 @@ public class AngleSnap implements ClientModInitializer {
         matrices.pop();
     }
 
-    private static void drawName(WorldRenderContext context, Vector3f pos, Quaternionf rotation, AngleEntry angle, float scale) {
+    private static void drawName(Camera camera, Matrix4f positionMatrix, Vector3f pos, Quaternionf rotation, AngleEntry angle, float scale) {
         if (scale == 0.0f || angle.name.isEmpty()) {
             return;
         }
 
-        MatrixStack matrices = Objects.requireNonNull(context.matrixStack());
+        MatrixStack matrices = new MatrixStack();
+        matrices.multiplyPositionMatrix(positionMatrix);
         matrices.push();
         matrices.translate(pos.x(), pos.y(), pos.z());
         matrices.multiply(rotation);

--- a/src/main/java/me/contaria/anglesnap/gui/camerasnap/CameraSnapListWidget.java
+++ b/src/main/java/me/contaria/anglesnap/gui/camerasnap/CameraSnapListWidget.java
@@ -5,6 +5,7 @@ import me.contaria.anglesnap.CameraPosEntry;
 import me.contaria.anglesnap.gui.screen.IconButtonWidget;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.Selectable;
@@ -38,7 +39,7 @@ public class CameraSnapListWidget extends ElementListWidget<CameraSnapListWidget
     private static final int HOVERED_COLOR = ColorHelper.getArgb(100, 200, 200, 200);
 
     public CameraSnapListWidget(MinecraftClient minecraftClient, int width, int height, int y) {
-        super(minecraftClient, width, height, y, 20, 25);
+        super(minecraftClient, width, height, y, 20);
 
         for (CameraPosEntry pos : AngleSnap.CONFIG.getCameraPositions()) {
             this.addEntry(new Entry(pos));
@@ -61,7 +62,6 @@ public class CameraSnapListWidget extends ElementListWidget<CameraSnapListWidget
         return this.width - 6;
     }
 
-    @Override
     protected void renderHeader(DrawContext context, int x, int y) {
         TextRenderer textRenderer = this.client.textRenderer;
         context.drawText(textRenderer, NAME_TEXT, x + 5, y + (20 - textRenderer.fontHeight) / 2, Colors.WHITE, true);
@@ -240,18 +240,23 @@ public class CameraSnapListWidget extends ElementListWidget<CameraSnapListWidget
         }
 
         @Override
-        public void render(DrawContext context, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
+        public void render(DrawContext context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
+            int x = this.getX();
+            int y = this.getY();
+            int entryWidth = this.getWidth();
+            int entryHeight = this.getHeight();
+
             if (hovered) {
                 context.fill(x, y, x + entryWidth, y + entryHeight, HOVERED_COLOR);
             }
             int textY = y + (entryHeight - this.client.textRenderer.fontHeight + 1) / 2;
-            this.renderTextWidgetAt(context, mouseX, mouseY, tickDelta, this.name, x + 5, textY);
-            this.renderNumberWidgetAt(context, mouseX, mouseY, tickDelta, this.x, x + 5 + 5 * entryWidth / 17, textY);
-            this.renderNumberWidgetAt(context, mouseX, mouseY, tickDelta, this.y, x + 5 + 7 * entryWidth / 17, textY);
-            this.renderNumberWidgetAt(context, mouseX, mouseY, tickDelta, this.z, x + 5 + 9 * entryWidth / 17, textY);
-            this.renderWidgetAt(context, mouseX, mouseY, tickDelta, this.edit, x + entryWidth - 5 - 40, y);
-            this.renderWidgetAt(context, mouseX, mouseY, tickDelta, this.save, x + entryWidth - 5 - 40, y);
-            this.renderWidgetAt(context, mouseX, mouseY, tickDelta, this.delete, x + entryWidth - 5 - 20, y);
+            this.renderTextWidgetAt(context, mouseX, mouseY, deltaTicks, this.name, x + 5, textY);
+            this.renderNumberWidgetAt(context, mouseX, mouseY, deltaTicks, this.x, x + 5 + 5 * entryWidth / 17, textY);
+            this.renderNumberWidgetAt(context, mouseX, mouseY, deltaTicks, this.y, x + 5 + 7 * entryWidth / 17, textY);
+            this.renderNumberWidgetAt(context, mouseX, mouseY, deltaTicks, this.z, x + 5 + 9 * entryWidth / 17, textY);
+            this.renderWidgetAt(context, mouseX, mouseY, deltaTicks, this.edit, x + entryWidth - 5 - 40, y);
+            this.renderWidgetAt(context, mouseX, mouseY, deltaTicks, this.save, x + entryWidth - 5 - 40, y);
+            this.renderWidgetAt(context, mouseX, mouseY, deltaTicks, this.delete, x + entryWidth - 5 - 20, y);
         }
 
         private void renderTextWidgetAt(DrawContext context, int mouseX, int mouseY, float tickDelta, TextFieldWidget widget, int x, int y) {
@@ -287,11 +292,11 @@ public class CameraSnapListWidget extends ElementListWidget<CameraSnapListWidget
         }
 
         @Override
-        public boolean mouseClicked(double mouseX, double mouseY, int button) {
-            if (super.mouseClicked(mouseX, mouseY, button)) {
+        public boolean mouseClicked(Click click, boolean doubled) {
+            if (super.mouseClicked(click, doubled)) {
                 return true;
             }
-            if (!this.editing && button == 0) {
+            if (!this.editing && click.button() == 0) {
                 AngleSnap.currentCameraPos = this.pos;
                 return true;
             }
@@ -307,8 +312,11 @@ public class CameraSnapListWidget extends ElementListWidget<CameraSnapListWidget
         }
 
         @Override
-        public void render(DrawContext context, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
-            this.renderWidgetAt(context, mouseX, mouseY, tickDelta, this.add, x + 5, y + (entryHeight - this.client.textRenderer.fontHeight) / 2);
+        public void render(DrawContext context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
+            int x = this.getX();
+            int y = this.getY();
+            int entryHeight = this.getHeight();
+            this.renderWidgetAt(context, mouseX, mouseY, deltaTicks, this.add, x + 5, y + (entryHeight - this.client.textRenderer.fontHeight) / 2);
         }
 
         private void add() {
@@ -320,8 +328,8 @@ public class CameraSnapListWidget extends ElementListWidget<CameraSnapListWidget
         }
 
         @Override
-        public boolean mouseClicked(double mouseX, double mouseY, int button) {
-            super.mouseClicked(mouseX, mouseY, button);
+        public boolean mouseClicked(Click click, boolean doubled) {
+            super.mouseClicked(click, doubled);
             return false;
         }
     }

--- a/src/main/java/me/contaria/anglesnap/gui/camerasnap/CameraSnapScreen.java
+++ b/src/main/java/me/contaria/anglesnap/gui/camerasnap/CameraSnapScreen.java
@@ -25,7 +25,8 @@ public class CameraSnapScreen extends Screen {
 
     @Override
     protected void init() {
-        this.addDrawableChild(new TextWidget(0, 10, this.width, 15, this.title, this.textRenderer).alignCenter());
+        int titleWidth = this.textRenderer.getWidth(this.title);
+        this.addDrawableChild(new TextWidget((this.width - titleWidth) / 2, 10, titleWidth, 15, this.title, this.textRenderer));
         this.addDrawableChild(new IconButtonWidget(this.width - 26, 10, CONFIGURE_TEXT, button -> MinecraftClient.getInstance().setScreen(new AngleSnapConfigScreen(this)), CONFIGURE_TEXTURE));
         this.addDrawableChild(new CameraSnapListWidget(this.client, this.width, this.height - 70, 35));
         this.addDrawableChild(ButtonWidget.builder(ScreenTexts.DONE, button -> this.close()).dimensions(this.width / 2 - 100, this.height - 27, 200, 20).build());

--- a/src/main/java/me/contaria/anglesnap/gui/config/AngleSnapConfigListWidget.java
+++ b/src/main/java/me/contaria/anglesnap/gui/config/AngleSnapConfigListWidget.java
@@ -4,6 +4,7 @@ import me.contaria.anglesnap.AngleSnap;
 import me.contaria.anglesnap.config.Option;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.Selectable;
@@ -19,7 +20,7 @@ public class AngleSnapConfigListWidget extends ElementListWidget<AngleSnapConfig
     private static final int HOVERED_COLOR = ColorHelper.getArgb(100, 200, 200, 200);
 
     public AngleSnapConfigListWidget(MinecraftClient minecraftClient, int width, int height, int y) {
-        super(minecraftClient, width, height, y, 24, 0);
+        super(minecraftClient, width, height, y, 24);
 
         for (Option<?> option : AngleSnap.CONFIG.getOptions()) {
             if (option.hasWidget()) {
@@ -94,19 +95,24 @@ public class AngleSnapConfigListWidget extends ElementListWidget<AngleSnapConfig
         }
 
         @Override
-        public void render(DrawContext context, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
+        public void render(DrawContext context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
+            int x = this.getX();
+            int y = this.getY();
+            int entryWidth = this.getWidth();
+            int entryHeight = this.getHeight();
+
             TextRenderer textRenderer = this.client.textRenderer;
             if (hovered) {
                 context.fill(x, y, x + entryWidth, y + entryHeight, HOVERED_COLOR);
             }
             int textY = y + (entryHeight - textRenderer.fontHeight + 1) / 2;
             context.drawText(textRenderer, this.option.getName(), x + 5, textY, Colors.WHITE, true);
-            this.renderWidgetAt(context, mouseX, mouseY, tickDelta, this.widget, x + 155, y);
+            this.renderWidgetAt(context, mouseX, mouseY, deltaTicks, this.widget, x + 155, y);
         }
 
         @Override
-        public boolean mouseClicked(double mouseX, double mouseY, int button) {
-            return super.mouseClicked(mouseX, mouseY, button);
+        public boolean mouseClicked(Click click, boolean doubled) {
+            return super.mouseClicked(click, doubled);
         }
     }
 }

--- a/src/main/java/me/contaria/anglesnap/gui/config/AngleSnapConfigScreen.java
+++ b/src/main/java/me/contaria/anglesnap/gui/config/AngleSnapConfigScreen.java
@@ -18,7 +18,8 @@ public class AngleSnapConfigScreen extends Screen {
 
     @Override
     protected void init() {
-        this.addDrawableChild(new TextWidget(0, 10, this.width, 15, this.title, this.textRenderer).alignCenter());
+        int titleWidth = this.textRenderer.getWidth(this.title);
+        this.addDrawableChild(new TextWidget((this.width - titleWidth) / 2, 10, titleWidth, 15, this.title, this.textRenderer));
         this.addDrawableChild(new AngleSnapConfigListWidget(this.client, this.width, this.height - 70, 35));
         this.addDrawableChild(ButtonWidget.builder(ScreenTexts.DONE, button -> this.close()).dimensions(this.width / 2 - 100, this.height - 27, 200, 20).build());
     }

--- a/src/main/java/me/contaria/anglesnap/gui/screen/AngleSnapListWidget.java
+++ b/src/main/java/me/contaria/anglesnap/gui/screen/AngleSnapListWidget.java
@@ -4,6 +4,7 @@ import me.contaria.anglesnap.AngleEntry;
 import me.contaria.anglesnap.AngleSnap;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.Selectable;
@@ -42,7 +43,7 @@ public class AngleSnapListWidget extends ElementListWidget<AngleSnapListWidget.A
     private final AngleSnapScreen parent;
 
     public AngleSnapListWidget(MinecraftClient minecraftClient, int width, int height, int y, AngleSnapScreen parent) {
-        super(minecraftClient, width, height, y, 20, 25);
+        super(minecraftClient, width, height, y, 20);
         this.parent = parent;
 
         for (AngleEntry angle : AngleSnap.CONFIG.getAngles()) {
@@ -66,7 +67,6 @@ public class AngleSnapListWidget extends ElementListWidget<AngleSnapListWidget.A
         return this.width - 6;
     }
 
-    @Override
     protected void renderHeader(DrawContext context, int x, int y) {
         TextRenderer textRenderer = this.client.textRenderer;
         context.drawText(textRenderer, NAME_TEXT, x + 5, y + (20 - textRenderer.fontHeight) / 2, Colors.WHITE, true);
@@ -268,36 +268,41 @@ public class AngleSnapListWidget extends ElementListWidget<AngleSnapListWidget.A
         }
 
         @Override
-        public void render(DrawContext context, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
+        public void render(DrawContext context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
+            int x = this.getX();
+            int y = this.getY();
+            int entryWidth = this.getWidth();
+            int entryHeight = this.getHeight();
+
             if (hovered) {
                 context.fill(x, y, x + entryWidth, y + entryHeight, HOVERED_COLOR);
             }
             int textY = y + (entryHeight - this.client.textRenderer.fontHeight + 1) / 2;
-            this.renderTextWidgetAt(context, mouseX, mouseY, tickDelta, this.name, x + 5, textY);
-            this.renderNumberWidgetAt(context, mouseX, mouseY, tickDelta, this.yaw, x + 5 + 5 * entryWidth / 17, textY);
-            this.renderNumberWidgetAt(context, mouseX, mouseY, tickDelta, this.pitch, x + 5 + 7 * entryWidth / 17, textY);
-            this.renderWidgetAt(context, mouseX, mouseY, tickDelta, this.icon, x + 5 + 9 * entryWidth / 17, y);
-            this.renderHexadecimalWidgetAt(context, mouseX, mouseY, tickDelta, this.color, x + 5 + 11 * entryWidth / 17, textY);
-            this.renderWidgetAt(context, mouseX, mouseY, tickDelta, this.edit, x + entryWidth - 5 - 40, y);
-            this.renderWidgetAt(context, mouseX, mouseY, tickDelta, this.save, x + entryWidth - 5 - 40, y);
-            this.renderWidgetAt(context, mouseX, mouseY, tickDelta, this.delete, x + entryWidth - 5 - 20, y);
+            this.renderTextWidgetAt(context, mouseX, mouseY, deltaTicks, this.name, x + 5, textY);
+            this.renderNumberWidgetAt(context, mouseX, mouseY, deltaTicks, this.yaw, x + 5 + 5 * entryWidth / 17, textY);
+            this.renderNumberWidgetAt(context, mouseX, mouseY, deltaTicks, this.pitch, x + 5 + 7 * entryWidth / 17, textY);
+            this.renderWidgetAt(context, mouseX, mouseY, deltaTicks, this.icon, x + 5 + 9 * entryWidth / 17, y);
+            this.renderHexadecimalWidgetAt(context, mouseX, mouseY, deltaTicks, this.color, x + 5 + 11 * entryWidth / 17, textY);
+            this.renderWidgetAt(context, mouseX, mouseY, deltaTicks, this.edit, x + entryWidth - 5 - 40, y);
+            this.renderWidgetAt(context, mouseX, mouseY, deltaTicks, this.save, x + entryWidth - 5 - 40, y);
+            this.renderWidgetAt(context, mouseX, mouseY, deltaTicks, this.delete, x + entryWidth - 5 - 20, y);
         }
 
-        private void renderTextWidgetAt(DrawContext context, int mouseX, int mouseY, float tickDelta, TextFieldWidget widget, int x, int y) {
+        private void renderTextWidgetAt(DrawContext context, int mouseX, int mouseY, float deltaTicks, TextFieldWidget widget, int x, int y) {
             if (this.editing) {
-                this.renderWidgetAt(context, mouseX, mouseY, tickDelta, widget, x, y);
+                this.renderWidgetAt(context, mouseX, mouseY, deltaTicks, widget, x, y);
             } else {
                 context.drawText(this.client.textRenderer, widget.getText(), x, y, Colors.WHITE, true);
             }
         }
 
-        private void renderNumberWidgetAt(DrawContext context, int mouseX, int mouseY, float tickDelta, TextFieldWidget widget, int x, int y) {
+        private void renderNumberWidgetAt(DrawContext context, int mouseX, int mouseY, float deltaTicks, TextFieldWidget widget, int x, int y) {
             if (this.isNumberOrEmpty(widget.getText())) {
-                this.renderTextWidgetAt(context, mouseX, mouseY, tickDelta, widget, x, y);
+                this.renderTextWidgetAt(context, mouseX, mouseY, deltaTicks, widget, x, y);
             } else {
                 widget.setEditableColor(Colors.LIGHT_RED);
                 widget.setUneditableColor(Colors.LIGHT_RED);
-                this.renderTextWidgetAt(context, mouseX, mouseY, tickDelta, widget, x, y);
+                this.renderTextWidgetAt(context, mouseX, mouseY, deltaTicks, widget, x, y);
                 widget.setEditableColor(Colors.WHITE);
                 widget.setUneditableColor(Colors.WHITE);
             }
@@ -315,13 +320,13 @@ public class AngleSnapListWidget extends ElementListWidget<AngleSnapListWidget.A
             }
         }
 
-        private void renderHexadecimalWidgetAt(DrawContext context, int mouseX, int mouseY, float tickDelta, TextFieldWidget widget, int x, int y) {
+        private void renderHexadecimalWidgetAt(DrawContext context, int mouseX, int mouseY, float deltaTicks, TextFieldWidget widget, int x, int y) {
             if (this.isHexadecimalOrEmpty(widget.getText())) {
-                this.renderTextWidgetAt(context, mouseX, mouseY, tickDelta, widget, x, y);
+                this.renderTextWidgetAt(context, mouseX, mouseY, deltaTicks, widget, x, y);
             } else {
                 widget.setEditableColor(Colors.LIGHT_RED);
                 widget.setUneditableColor(Colors.LIGHT_RED);
-                this.renderTextWidgetAt(context, mouseX, mouseY, tickDelta, widget, x, y);
+                this.renderTextWidgetAt(context, mouseX, mouseY, deltaTicks, widget, x, y);
                 widget.setEditableColor(Colors.WHITE);
                 widget.setUneditableColor(Colors.WHITE);
             }
@@ -345,11 +350,11 @@ public class AngleSnapListWidget extends ElementListWidget<AngleSnapListWidget.A
         }
 
         @Override
-        public boolean mouseClicked(double mouseX, double mouseY, int button) {
-            if (super.mouseClicked(mouseX, mouseY, button)) {
+        public boolean mouseClicked(Click click, boolean doubled) {
+            if (super.mouseClicked(click, doubled)) {
                 return true;
             }
-            if (!this.editing && button == 0) {
+            if (!this.editing && click.button() == 0) {
                 AngleSnapListWidget.this.parent.snap(this.angle);
                 return true;
             }
@@ -365,8 +370,11 @@ public class AngleSnapListWidget extends ElementListWidget<AngleSnapListWidget.A
         }
 
         @Override
-        public void render(DrawContext context, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
-            this.renderWidgetAt(context, mouseX, mouseY, tickDelta, this.add, x + 5, y + (entryHeight - this.client.textRenderer.fontHeight) / 2);
+        public void render(DrawContext context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
+            int x = this.getX();
+            int y = this.getY();
+            int entryHeight = this.getHeight();
+            this.renderWidgetAt(context, mouseX, mouseY, deltaTicks, this.add, x + 5, y + (entryHeight - this.client.textRenderer.fontHeight) / 2);
         }
 
         private void add() {
@@ -378,8 +386,8 @@ public class AngleSnapListWidget extends ElementListWidget<AngleSnapListWidget.A
         }
 
         @Override
-        public boolean mouseClicked(double mouseX, double mouseY, int button) {
-            super.mouseClicked(mouseX, mouseY, button);
+        public boolean mouseClicked(Click click, boolean doubled) {
+            super.mouseClicked(click, doubled);
             return false;
         }
     }

--- a/src/main/java/me/contaria/anglesnap/gui/screen/AngleSnapScreen.java
+++ b/src/main/java/me/contaria/anglesnap/gui/screen/AngleSnapScreen.java
@@ -25,7 +25,8 @@ public class AngleSnapScreen extends Screen {
 
     @Override
     protected void init() {
-        this.addDrawableChild(new TextWidget(0, 10, this.width, 15, this.title, this.textRenderer).alignCenter());
+        int titleWidth = this.textRenderer.getWidth(this.title);
+        this.addDrawableChild(new TextWidget((this.width - titleWidth) / 2, 10, titleWidth, 15, this.title, this.textRenderer));
         this.addDrawableChild(new IconButtonWidget(this.width - 26, 10, CONFIGURE_TEXT, button -> MinecraftClient.getInstance().setScreen(new AngleSnapConfigScreen(this)), CONFIGURE_TEXTURE));
         this.addDrawableChild(new AngleSnapListWidget(this.client, this.width, this.height - 70, 35, this));
         this.addDrawableChild(ButtonWidget.builder(ScreenTexts.DONE, button -> this.close()).dimensions(this.width / 2 - 100, this.height - 27, 200, 20).build());

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -40,7 +40,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.16.10",
-    "minecraft": ">=1.21.6 <=1.21.10",
+    "minecraft": ">=1.21.9 <=1.21.10",
     "java": ">=21",
     "fabric-api": ">=0.128.0"
   }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -40,7 +40,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.16.10",
-    "minecraft": ">=1.21.6 <=1.21.8",
+    "minecraft": ">=1.21.6 <=1.21.10",
     "java": ">=21",
     "fabric-api": ">=0.128.0"
   }


### PR DESCRIPTION
  - Update gradle properties to Minecraft 1.21.10 and Fabric API 0.136.0+1.21.10
  - Refactor KeyBinding initialization to use KeyBinding.Category
  - Update fabric.mod.json version constraints to 1.21.6-1.21.10
  - Update all GUI screens for Fabric API compatibility

  Note: Angle marker world rendering is temporarily disabled pending resolution
  of WorldRenderEvents API changes in Fabric.